### PR TITLE
use yaml.safe_load instead of deprecated yaml.load

### DIFF
--- a/colcon_metadata/metadata/colcon_pkg.py
+++ b/colcon_metadata/metadata/colcon_pkg.py
@@ -77,4 +77,4 @@ class ColconPkgPackageIdentification(
         if not colcon_pkg_path.is_file():
             return None
         content = colcon_pkg_path.read_text()
-        return yaml.load(content)
+        return yaml.safe_load(content)

--- a/colcon_metadata/metadata/repository.py
+++ b/colcon_metadata/metadata/repository.py
@@ -32,7 +32,7 @@ def get_repositories():
     if metadata_repositories_file.is_dir():
         raise IsADirectoryError()
     content = metadata_repositories_file.read_text()
-    data = yaml.load(content)
+    data = yaml.safe_load(content)
     assert isinstance(data, dict), 'The content of the configuration file ' \
         "'%s' should be a dictionary" % metadata_repositories_file
     return data

--- a/colcon_metadata/package_discovery/colcon_meta.py
+++ b/colcon_metadata/package_discovery/colcon_meta.py
@@ -66,7 +66,7 @@ class ColconMetadataDiscovery(PackageDiscoveryExtensionPoint):
     def _add(self, meta_path):
         content = meta_path.read_text()
         try:
-            data = yaml.load(content)
+            data = yaml.safe_load(content)
         except Exception as e:
             logger.warning(
                 "Skipping metadata file '%s' since it failed to parse: %s" %

--- a/colcon_metadata/subverb/update.py
+++ b/colcon_metadata/subverb/update.py
@@ -68,7 +68,7 @@ class UpdateMetadataSubverb(MetadataSubverbExtensionPoint):
 
             # parse the repository index
             try:
-                data = yaml.load(content)
+                data = yaml.safe_load(content)
             except Exception as e:
                 print(' ', str(e), file=sys.stderr)
                 rc = 1


### PR DESCRIPTION
This is the first of a series of PR, once this is reviewed, I'll submit similar PRs to other packages.

`yaml.load()` without specifying a Loader is now deprecated for security reasons, more details at  https://msg.pyyaml.org/load

This PR switches to `yaml.safe_load()`, this support all native YAML tags so I think should be sufficient for this use case and appropriate as the loaded content is not trusted. Alternative would be to use `yaml.full_load` to keep the exact same behavior and suppress the warning.

From [PyYAMLDocumentation](https://pyyaml.org/wiki/PyYAMLDocumentation):
> safe_load(stream) parses the given stream and returns a Python object constructed from for the first document in the stream. If there are no documents in the stream, it returns None. safe_load recognizes only standard YAML tags and cannot construct an arbitrary Python object.
> A python object can be marked as safe and thus be recognized by yaml.safe_load. To do this, derive it from yaml.YAMLObject (as explained in section Constructors, representers, resolvers) and explicitly set its class property yaml_loader to yaml.SafeLoader.
---

Noticed this as the following message appeared when trying to build a workspace using colcon:
```
/usr/lib/python3/dist-packages/colcon_metadata/metadata/colcon_pkg.py:81: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```