### PR TITLE
fix default value of --metas argument

### DIFF
--- a/colcon_metadata/package_discovery/colcon_meta.py
+++ b/colcon_metadata/package_discovery/colcon_meta.py
@@ -38,7 +38,7 @@ class ColconMetadataDiscovery(PackageDiscoveryExtensionPoint):
             '--metas',
             nargs='*',
             metavar='PATH',
-            default='./colcon.meta',
+            default=['./colcon.meta'],
             help='The directories containing a `colcon.meta` file or paths to '
                  'arbitrary files containing the same meta information '
                  '(default: ./colcon.meta)')


### PR DESCRIPTION
Without the patch the default string `./colcon.meta` was interpreted as an iterable and each character was checked if a file with that name existed.