### PR TITLE
Fix blind except flake8 errors

### DIFF
--- a/colcon_metadata/package_discovery/colcon_meta.py
+++ b/colcon_metadata/package_discovery/colcon_meta.py
@@ -68,7 +68,7 @@ class ColconMetadataDiscovery(PackageDiscoveryExtensionPoint):
         content = meta_path.read_text()
         try:
             data = yaml.safe_load(content)
-        except Exception as e:
+        except Exception as e:  # noqa: B902 (possible exceptions unclear)
             logger.warning(
                 "Skipping metadata file '%s' since it failed to parse: %s" %
                 (meta_path.absolute(), e))

--- a/colcon_metadata/subverb/update.py
+++ b/colcon_metadata/subverb/update.py
@@ -2,7 +2,10 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
+import socket
 import sys
+from urllib.error import HTTPError
+from urllib.error import URLError
 
 from colcon_core.plugin_system import satisfies_version
 from colcon_metadata.metadata import get_metadata_files
@@ -61,7 +64,7 @@ class UpdateMetadataSubverb(MetadataSubverbExtensionPoint):
             print('fetching {name}: {index_url} ...'.format_map(locals()))
             try:
                 content = load_url(index_url)
-            except Exception as e:
+            except (HTTPError, URLError, socket.timeout) as e:
                 print(' ', str(e), file=sys.stderr)
                 rc = 1
                 continue
@@ -69,7 +72,7 @@ class UpdateMetadataSubverb(MetadataSubverbExtensionPoint):
             # parse the repository index
             try:
                 data = yaml.safe_load(content)
-            except Exception as e:
+            except Exception as e:  # noqa: B902 (possible exceptions unclear)
                 print(' ', str(e), file=sys.stderr)
                 rc = 1
                 continue
@@ -99,7 +102,7 @@ class UpdateMetadataSubverb(MetadataSubverbExtensionPoint):
                 print('  fetching {metadata_url} ...'.format_map(locals()))
                 try:
                     content = load_url(metadata_url)
-                except Exception as e:
+                except (HTTPError, URLError, socket.timeout) as e:
                     print('  -', str(e), file=sys.stderr)
                     rc = 1
                     continue

--- a/colcon_metadata/subverb/update.py
+++ b/colcon_metadata/subverb/update.py
@@ -2,10 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
-import socket
 import sys
-from urllib.error import HTTPError
-from urllib.error import URLError
 
 from colcon_core.plugin_system import satisfies_version
 from colcon_metadata.metadata import get_metadata_files
@@ -64,7 +61,7 @@ class UpdateMetadataSubverb(MetadataSubverbExtensionPoint):
             print('fetching {name}: {index_url} ...'.format_map(locals()))
             try:
                 content = load_url(index_url)
-            except (HTTPError, URLError, socket.timeout) as e:
+            except Exception as e:  # noqa: B902
                 print(' ', str(e), file=sys.stderr)
                 rc = 1
                 continue
@@ -72,7 +69,7 @@ class UpdateMetadataSubverb(MetadataSubverbExtensionPoint):
             # parse the repository index
             try:
                 data = yaml.safe_load(content)
-            except Exception as e:  # noqa: B902 (possible exceptions unclear)
+            except Exception as e:  # noqa: B902
                 print(' ', str(e), file=sys.stderr)
                 rc = 1
                 continue
@@ -102,7 +99,7 @@ class UpdateMetadataSubverb(MetadataSubverbExtensionPoint):
                 print('  fetching {metadata_url} ...'.format_map(locals()))
                 try:
                     content = load_url(metadata_url)
-                except (HTTPError, URLError, socket.timeout) as e:
+                except Exception as e:  # noqa: B902
                     print('  -', str(e), file=sys.stderr)
                     rc = 1
                     continue


### PR DESCRIPTION
Explicitly list expected types where possible.

I've chosen to suppress the linter check in cases where yaml.safe_load()
is used since it is not obvious what exceptions may be raised.

This should fix CI ([example failure](https://travis-ci.org/github/colcon/colcon-metadata/builds/757995866)).